### PR TITLE
Fix crash caused by outdated map animation state

### DIFF
--- a/src/components/map/MapContainer.js
+++ b/src/components/map/MapContainer.js
@@ -1,16 +1,21 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
 import ReactMapGL, { NavigationControl } from 'react-map-gl';
-// components
+// Components
 import ClusterMarkers from './ClusterMarkers';
 import MapSearch from './MapSearch';
 import SearchHeader from './incidentContainer/SearchHeader';
-import useViewport from './../../hooks/useViewport';
+// Hooks
+import useViewport from '../../hooks/useViewport';
+import useCleanMap from '../../hooks/useCleanMap';
 
 function MapContainer() {
-  const maxZoom = 17;
+  // Ensures old transition animation state is cleaned up, prevents a crash
+  useCleanMap();
 
   const { viewport, setViewport } = useViewport();
+
+  const maxZoom = 17;
 
   const incidentsOfInterest = useSelector(
     state => state.map.incidentsOfInterest

--- a/src/hooks/legacy/useIncidents.js
+++ b/src/hooks/legacy/useIncidents.js
@@ -20,7 +20,6 @@ export function useIncidents() {
     const { data } = await axios.get(
       `${process.env.REACT_APP_BACKENDURL}/incidents/getincidents`
     );
-    console.log(data);
     return data;
   }, []);
 

--- a/src/hooks/useCleanMap.js
+++ b/src/hooks/useCleanMap.js
@@ -1,0 +1,13 @@
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+import { mapActions } from '../store';
+
+const { cleanTransition } = mapActions;
+
+export default function useCleanMap() {
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    return () => dispatch(cleanTransition());
+  });
+}

--- a/src/store/mapSlice.js
+++ b/src/store/mapSlice.js
@@ -46,6 +46,11 @@ const slice = createSlice({
     setSearch: (state, action) => {
       state.search = action.payload;
     },
+    cleanTransition: (state, action) => {
+      if (state.viewport.transitionDuration) {
+        state.viewport.transitionDuration = 0;
+      }
+    },
   },
 });
 


### PR DESCRIPTION
# Description

Fixes bug that would cause the application to crash if the user zoomed on the map, navigated to another page, and then returned to the homepage/map. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Change Status

- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?

- `npm run test`

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
