### PR TITLE
edited built by lambda logo in nav bar

### DIFF
--- a/src/components/NavBar/NavBar.js
+++ b/src/components/NavBar/NavBar.js
@@ -53,11 +53,9 @@ const NavBar = () => {
               </NavLink>
             </Menu.Item> */}
 
-            <Menu.Item key="6">
-              <div className="lambda-container">
-                <img src={lambda} alt="Built By Lambda" className="lambda" />
-              </div>
-            </Menu.Item>
+            <div className="lambda-container">
+              <img src={lambda} alt="Built By Lambda" className="lambda" />
+            </div>
           </Menu>
         </Layout>
       </nav>

--- a/src/components/NavBar/nav.scss
+++ b/src/components/NavBar/nav.scss
@@ -33,9 +33,13 @@ root:hover {
     background-color: var(--blue);
   }
   .lambda-container {
-    max-height: 2.5rem;
+    // max-height: 2.5rem;
+    display: flex;
+    align-items: center;
 
     .lambda {
+      margin-top: 5px;
+      margin-left: 3px;
       max-height: 2.5rem;
     }
   }
@@ -70,10 +74,9 @@ nav {
   color: #fff;
 }
 
-
 /* overrides for ant design */
-
 
 .ant-menu-horizontal.override {
   line-height: 52px;
+  box-shadow: 15px;
 }


### PR DESCRIPTION
# Description
Centers the lambda logo on the navbar properly, and takes away on-hover effect

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Change Status

- [ ] Complete, but not tested (may need new tests)

# How Has This Been Tested?

- [ ] `npm test`

# Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] There are no merge conflicts
