### PR TITLE
moved logged out of footer

### DIFF
--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -4,10 +4,10 @@ import { Link, NavLink } from 'react-router-dom';
 import { Layout, Menu } from 'antd';
 
 const Footer = () => {
-  const logout = () => {
-    localStorage.removeItem('okta-token-storage', 'okta-cache-storage');
-    window.location.reload();
-  };
+  // const logout = () => {
+  //   localStorage.removeItem('okta-token-storage', 'okta-cache-storage');
+  //   window.location.reload();
+  // };
 
   return (
     <div className="footer-container">
@@ -23,6 +23,7 @@ const Footer = () => {
                     exact
                     className="nav-link"
                     activeClassName="active-nav-link"
+                    rel="noreferrer"
                   >
                     Human Rights First
                   </a>
@@ -36,11 +37,11 @@ const Footer = () => {
                     Administration
                   </NavLink>
                 </Menu.Item>
-                <Menu.Item key="3" className="logout" onClick={logout}>
+                {/* <Menu.Item key="3" className="logout" onClick={logout}>
                   <NavLink to="/" activeClassName="active-nav-link">
                     Log out
                   </NavLink>
-                </Menu.Item>
+                </Menu.Item> */}
               </Menu>
 
               <p>Human Rights First &copy;2021</p>

--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -2,12 +2,15 @@ import React from 'react';
 import 'antd/dist/antd.css';
 import { Link, NavLink } from 'react-router-dom';
 import { Layout, Menu } from 'antd';
+import { useOktaAuth } from '@okta/okta-react';
 
 const Footer = () => {
-  // const logout = () => {
-  //   localStorage.removeItem('okta-token-storage', 'okta-cache-storage');
-  //   window.location.reload();
-  // };
+  const logout = () => {
+    localStorage.removeItem('okta-token-storage', 'okta-cache-storage');
+    window.location.reload();
+  };
+
+  const { authState } = useOktaAuth();
 
   return (
     <div className="footer-container">
@@ -37,11 +40,13 @@ const Footer = () => {
                     Administration
                   </NavLink>
                 </Menu.Item>
-                {/* <Menu.Item key="3" className="logout" onClick={logout}>
-                  <NavLink to="/" activeClassName="active-nav-link">
-                    Log out
-                  </NavLink>
-                </Menu.Item> */}
+                {authState.isAuthenticated && (
+                  <Menu.Item key="3" className="logout" onClick={logout}>
+                    <NavLink to="/" activeClassName="active-nav-link">
+                      Log out
+                    </NavLink>
+                  </Menu.Item>
+                )}
               </Menu>
 
               <p>Human Rights First &copy;2021</p>
@@ -63,3 +68,6 @@ const Footer = () => {
 };
 
 export default Footer;
+
+// &&
+// localStorage.getItem('okta-cache-storage')


### PR DESCRIPTION
# Description
Brandon S and Robert M and Jean L figured out a way to not display the "Log-out" link on footer unless you are signed into the website as an Administator. We imported the useOktaAuth from Okta's library (which is what our login Auth was using) and basically stated unless the authenticated state on the webpage is TRUE and only if it is true will the log-out link display. This ensures  consistency throughout webpage as a user vs an administrator

Fixes # (issue)

## Type of change
 We imported the useOktaAuth from Okta's library (which is what our login Auth was using) and basically stated unless the authenticated state on the webpage is TRUE then the "logout" can be displayed at the footer.
Please delete options that are not relevant.


- [ ] New feature (non-breaking change which adds functionality)


## Change Status

- [ ] Complete, tested, ready to review and merge

# How Has This Been Tested?

- [ ] `npm test`

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
