### PR TITLE
Second Option On LogOut w/ A button on the AdminDashBoard instead

### DIFF
--- a/src/components/AdminDashboard/AdminDashboard.css
+++ b/src/components/AdminDashboard/AdminDashboard.css
@@ -13,6 +13,7 @@ root {
 
 .dashboard-buttons-container {
   display: flex;
+  justify-content: space-between;
   padding-top: 3rem;
   width: 90%;
   margin: auto;

--- a/src/components/AdminDashboard/AdminDashboard.js
+++ b/src/components/AdminDashboard/AdminDashboard.js
@@ -17,6 +17,7 @@ import { DoubleRightOutlined } from '@ant-design/icons';
 import { DoubleLeftOutlined } from '@ant-design/icons';
 
 import axios from 'axios';
+import { useHistory } from 'react-router-dom';
 
 const AdminDashboard = () => {
   // setting up local state to keep track of selected/"checked" incidents
@@ -46,6 +47,10 @@ const AdminDashboard = () => {
 
   const [showModal, setShowModal] = useState(false);
   const HAS_VISITED_BEFORE = localStorage.getItem('hasVisitedBefore');
+
+  //variable to push to homepage for logout button
+
+  const { push } = useHistory();
 
   useEffect(() => {
     const handleShowModal = () => {
@@ -176,6 +181,12 @@ const AdminDashboard = () => {
     setAdding(true);
   };
 
+  const logout = () => {
+    localStorage.removeItem('okta-token-storage', 'okta-cache-storage');
+    push('/');
+    window.location.reload();
+  };
+
   return (
     <>
       {showModal ? <div className="back-drop"></div> : null}
@@ -186,12 +197,19 @@ const AdminDashboard = () => {
       />
 
       <div className="dashboard-buttons-container">
-        <button className="approve-btn" onClick={() => setUnapproved(true)}>
-          Unapproved Incidents
-        </button>
-        <button className="approve-btn" onClick={() => setUnapproved(false)}>
-          Approved Incidents
-        </button>
+        <div className="incident-btn-container">
+          <button className="approve-btn" onClick={() => setUnapproved(true)}>
+            Unapproved Incidents
+          </button>
+          <button className="approve-btn" onClick={() => setUnapproved(false)}>
+            Approved Incidents
+          </button>
+        </div>
+        <div className="logout-container">
+          <button className="approve-btn" onClick={logout}>
+            Log Out
+          </button>
+        </div>
       </div>
       {unapproved ? (
         <div className="dashboard-container">

--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -4,10 +4,10 @@ import { Link, NavLink } from 'react-router-dom';
 import { Layout, Menu } from 'antd';
 
 const Footer = () => {
-  const logout = () => {
-    localStorage.removeItem('okta-token-storage', 'okta-cache-storage');
-    window.location.reload();
-  };
+  // const logout = () => {
+  //   localStorage.removeItem('okta-token-storage', 'okta-cache-storage');
+  //   window.location.reload();
+  // };
 
   return (
     <div className="footer-container">
@@ -23,6 +23,7 @@ const Footer = () => {
                     exact
                     className="nav-link"
                     activeClassName="active-nav-link"
+                    rel="noreferrer"
                   >
                     Human Rights First
                   </a>
@@ -36,11 +37,11 @@ const Footer = () => {
                     Administration
                   </NavLink>
                 </Menu.Item>
-                <Menu.Item key="3" className="logout" onClick={logout}>
+                {/* <Menu.Item key="3" className="logout" onClick={logout}>
                   <NavLink to="/" activeClassName="active-nav-link">
                     Log out
                   </NavLink>
-                </Menu.Item>
+                </Menu.Item> */}
               </Menu>
 
               <p>Human Rights First &copy;2021</p>

--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -2,12 +2,19 @@ import React from 'react';
 import 'antd/dist/antd.css';
 import { Link, NavLink } from 'react-router-dom';
 import { Layout, Menu } from 'antd';
+import { useOktaAuth } from '@okta/okta-react';
+import { useHistory } from 'react-router-dom';
 
 const Footer = () => {
-  // const logout = () => {
-  //   localStorage.removeItem('okta-token-storage', 'okta-cache-storage');
-  //   window.location.reload();
-  // };
+  const { push } = useHistory();
+
+  const { authState } = useOktaAuth();
+
+  const logout = () => {
+    localStorage.removeItem('okta-token-storage', 'okta-cache-storage');
+    push('/');
+    window.location.reload();
+  };
 
   return (
     <div className="footer-container">
@@ -37,13 +44,14 @@ const Footer = () => {
                     Administration
                   </NavLink>
                 </Menu.Item>
-                {/* <Menu.Item key="3" className="logout" onClick={logout}>
-                  <NavLink to="/" activeClassName="active-nav-link">
-                    Log out
-                  </NavLink>
-                </Menu.Item> */}
+                {authState.isAuthenticated && (
+                  <Menu.Item key="3" className="logout" onClick={logout}>
+                    <NavLink to="/" activeClassName="active-nav-link">
+                      Log out
+                    </NavLink>
+                  </Menu.Item>
+                )}
               </Menu>
-
               <p>Human Rights First &copy;2021</p>
             </div>
           </Layout>


### PR DESCRIPTION
# Description

Brandon S and Robert P Have come up with a second option on the logout functionality here. We decided to create a button that is placed on the top right of the admin dashboard. This button only appears within the admin dashboard and nowhere else on the webpage, so when the admin is on his/her dashboard they can log-out accordingly. However we decide to combine the first iteration into this option where we combine the "log out" in the footer if an admin is signed in and keep the button on the dash board as well, so the admin has control on the top and bottom of the page( Approved). So now button and tenerary are both implemented inside the code base.

Fixes # (issue)

The fix we implemented was creating a button that admin can press to log out of the page and proceed to the homepage.This was put inside of the admin dashboard. We also put a ternerary operator inside the footer so log out only displays if an authenicated admin is logged in. So every user has to see a random log out on the bottom of their page.

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

## Change Status

- [ ] Complete, but not tested (may need new tests)

# How Has This Been Tested?

- [ ] `npm test`

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
