### PR TITLE
adds 10px padding above arrow on the timeline card

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -498,6 +498,7 @@ div.timeline-container {
 .timeline-button {
   width: 100%;
   font-size: large;
+  padding: 10px 0 0 0;
 }
 
 .timeline-wrapper {


### PR DESCRIPTION
# Description
Design change adds 10px padding to the top of the arrows on the timeline cards. It allows for better visibility.
Fixes # (issue)

## Type of change
UI/UX Change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

## Change Status

- [ ] Complete, tested, ready to review and merge

# How Has This Been Tested?

- [ ] `npm test`

# Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] There are no merge conflicts
