### PR TITLE
improve search functionality on graph page by hiding bar graph on U.S…

### DIFF
--- a/src/components/graphs/GraphContainer.css
+++ b/src/components/graphs/GraphContainer.css
@@ -76,4 +76,8 @@
   display: inline;
 }
 
+#selectedTotal{
+  margin-top: 4rem;
+}
+
 /*# sourceMappingURL=GraphContainer.css.map */

--- a/src/components/graphs/GraphContainer.js
+++ b/src/components/graphs/GraphContainer.js
@@ -174,21 +174,15 @@ const GraphContainer = () => {
             noDataDisplay()
           )}
         </section>
-        {filtered.length > 0 ? (
-          <div>
-            {/* if user selects U.S. State bar graph disappears*/}
-            {!usState && (
-              <section id="barGraph" className="graph-container">
-                <div>
-                  <h2 style={{ marginTop: '5rem' }}>
-                    Total incident reports identified by our data collection
-                    methods by state
-                  </h2>
-                </div>
-                <BarGraph count={barCounts} />
-              </section>
-            )}
-          </div>
+        {/* if user selects U.S. State bar graph disappears*/}
+        {filtered.length > 0 && !usState ? (
+          <section id="barGraph" className="graph-container">
+            <h2 style={{ marginTop: '5rem' }}>
+              Total incident reports identified by our data collection methods
+              by state
+            </h2>
+            <BarGraph count={barCounts} />
+          </section>
         ) : null}
         {filtered.length > 0 ? (
           <div>

--- a/src/components/graphs/GraphContainer.js
+++ b/src/components/graphs/GraphContainer.js
@@ -148,6 +148,13 @@ const GraphContainer = () => {
       </header>
 
       <div className="all-graphs-container">
+        {/* if user selects U.S. State display total # of incidents */}
+        {usState && (
+          <h2 id="selectedTotal">
+            {' '}
+            The Total Number of Incidents in {usState} is {filtered.length}
+          </h2>
+        )}
         <section id="lineGraph" className="graph-container">
           {filtered.length > 0 ? (
             <div className="all-graphs">
@@ -169,15 +176,22 @@ const GraphContainer = () => {
         </section>
         {filtered.length > 0 ? (
           <div>
-            <section id="barGraph" className="graph-container">
-              <div>
-                <h2 style={{ marginTop: '5rem' }}>
-                  Total incident reports identified by our data collection
-                  methods by state
-                </h2>
-              </div>
-              <BarGraph count={barCounts} />
-            </section>
+            {/* if user selects U.S. State bar graph disappears*/}
+            {!usState && (
+              <section id="barGraph" className="graph-container">
+                <div>
+                  <h2 style={{ marginTop: '5rem' }}>
+                    Total incident reports identified by our data collection
+                    methods by state
+                  </h2>
+                </div>
+                <BarGraph count={barCounts} />
+              </section>
+            )}
+          </div>
+        ) : null}
+        {filtered.length > 0 ? (
+          <div>
             <section id="pieGraph" className="graph-container">
               <h2 style={{ marginTop: '5rem' }}>
                 Prevalence of Force Ranks as identified by our data collection


### PR DESCRIPTION
# Description
Graph page had poor UI for when searching by individual U.S. State. We changed the logic so when the search is active the bar graph disappears and it shows total incidents in that state instead of bar graph. 

Fixes # (issue)
Poor UI on graph page when searching by U.S. State

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue

## Change Status
- [x] Complete, but not tested (may need new tests)

# How Has This Been Tested?
- [x] `npm test`

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts

#Collaborators 
Alex Ardanov
Casey Cerrito
Kirk Snyder
