### PR TITLE
added margin-left and top to panel heading so that dropdown arrow wou…

### DIFF
--- a/src/components/incidents/Incidents.css
+++ b/src/components/incidents/Incidents.css
@@ -4,6 +4,10 @@
   display: flex;
   justify-content: space-between;
 }
+#title {
+  margin-top: 2px;
+  margin-left: 25px;
+}
 .incidents-container {
   max-width: 92vw;
   margin: auto;
@@ -26,6 +30,7 @@
 .collapse-content {
   display: flex;
 }
+
 .incidents-page header .user-input {
   display: -webkit-box;
   display: -ms-flexbox;

--- a/src/components/incidents/Incidents.js
+++ b/src/components/incidents/Incidents.js
@@ -57,7 +57,7 @@ const Incidents = () => {
   const header = incident => {
     return (
       <div className="header-top">
-        <p>{incident.title}</p>
+        <p id="title">{incident.title}</p>
         <div className="extra">
           <div className="tag-group">
             <Tag>{incident.categories[0]}</Tag>


### PR DESCRIPTION
# Description
added margin-left and top to panel heading so that dropdown arrow would be visible on the incidents report page. In order to do this I added an id to the incident title on line 60 in Incidents.js, and then added the needed styling in Incidents.css.

Fixes # (issue)
This fixes the issue of the panel dropdown arrow not being visible due to the heading being rendered on top of the arrow.

## Type of change
UI design change. 

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] There are no merge conflicts
