### PR TITLE
Fixed Blue Colors on Incident Reports Page

### DIFF
--- a/src/components/incidents/Incidents.css
+++ b/src/components/incidents/Incidents.css
@@ -66,6 +66,28 @@
   padding-bottom: 2.5vh;
 }
 
+span.ant-tag.ant-tag-checkable:hover {
+  color: rgb(47, 84, 235);
+}
+
+.ant-tag-checkable-checked {
+  background-color: rgb(47, 84, 235);
+}
+
+span.ant-tag.ant-tag-checkable-checked:hover {
+  color: #ffffff;
+}
+
+.ant-pagination-item a:hover {
+  color: rgb(47, 84, 235);
+  border-color: rgb(47, 84, 235);
+}
+
+.ant-pagination-item-active a {
+  color: rgb(47, 84, 235);
+  border-color: rgb(47, 84, 235);
+}
+
 @media screen and (max-width: 1081px) {
   .incidents-page header {
     -webkit-box-orient: vertical;

--- a/src/components/incidents/Incidents.js
+++ b/src/components/incidents/Incidents.js
@@ -296,7 +296,10 @@ const Incidents = () => {
                       >
                         <Button
                           type="primary"
-                          style={{ backgroundColor: '#003767', border: 'none' }}
+                          style={{
+                            backgroundColor: 'rgb(47, 84, 235)',
+                            border: 'none',
+                          }}
                         >
                           Sources
                         </Button>

--- a/src/components/incidents/Incidents.js
+++ b/src/components/incidents/Incidents.js
@@ -203,7 +203,7 @@ const Incidents = () => {
           description={
             <span>
               There are no incident reports matching these search criteria.
-              <span style={{ color: '#1890ff' }}>{usState}</span>
+              <span style={{ color: 'rgb(47, 84, 235)' }}>{usState}</span>
             </span>
           }
         />
@@ -243,7 +243,11 @@ const Incidents = () => {
                 Date: <RangePicker onCalendarChange={onDateSelection} />
               </label>
 
-              <Button onClick={downloadCSV} type="primary">
+              <Button
+                onClick={downloadCSV}
+                type="primary"
+                style={{ background: 'rgb(47, 84, 235)' }}
+              >
                 Export List
               </Button>
             </fieldset>


### PR DESCRIPTION
Fixed the blue colors on the incident reports page to match the color of the navigation bar.

1. Fixed Export List button color
2. Fixed category checkbox selected color
3. Fixed category hover color
4. Fixed pagination items color
5. Fixed state name color shown when no incidents data available
6. Fixed color for 'Sources' button to match nav bar.

Color changes: light blue: #1890ff or ant-design default > navigation's blue: rgb(47, 84, 235)

- [x] Bug fix (non-breaking change which fixes an issue)

- [x] Complete, tested, ready to review and merge

Changes have been viewed locally.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
