### PR TITLE
remove cluster at (0, 0) from displaying on map

### DIFF
--- a/src/components/Home/Map/Clusters.js
+++ b/src/components/Home/Map/Clusters.js
@@ -68,6 +68,10 @@ export default function Clusters({ zoomOnCluster }) {
             }
           : { isCluster: false, pointCount: 1 };
 
+        if (longitude === 0 && latitude === 0) {
+          return null;
+        }
+
         return (
           <Marker
             key={nanoid()}


### PR DESCRIPTION
# Description

Incident reports with no location caused clusters to display on the map off the coast of Africa at (0, 0). This change removes the clusters from the map.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# Checklist

- [ ] filter clusters with a longitude and latitude of 0, 0

Co-author: @YourPersonalTechGuy 
