### PR TITLE
centers homepage bottom buttons

### DIFF
--- a/src/components/Stats/Stats.js
+++ b/src/components/Stats/Stats.js
@@ -58,7 +58,11 @@ const Stats = () => {
         <Button style={{ margin: '.5rem' }} shape="round" ghost>
           <Link to="/incident-reports">Incident Reports</Link>
         </Button>
-        <Button style={{ margin: '.5rem' }} shape="round" ghost>
+        <Button
+          style={{ marginLeft: '3rem', padding: '0 3rem' }}
+          shape="round"
+          ghost
+        >
           <Link to="/about">About</Link>
         </Button>
       </div>


### PR DESCRIPTION
# Description
Centers homepage bottom buttons(Incident Reports, About) and make the About button the same size as the Incidents Reports.
Fixes # (issue)
The buttons were too far to the right and not center.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Change Status

- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

- [ ] `npm test`

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
