### PR TITLE
Revert change that removed compass control

### DIFF
--- a/src/components/Home/Map/Map.js
+++ b/src/components/Home/Map/Map.js
@@ -116,7 +116,7 @@ export default function Map() {
             <>
               <Search zoomOnCluster={zoomOnCluster} />
               <NavControlContainer>
-                <NavigationControl showCompass={null} />
+                <NavigationControl />
                 <HomeIcon
                   zoomOnCluster={zoomOnCluster}
                   initialPosition={initialPosition}


### PR DESCRIPTION
# Description

Reverts changes that removed the compass control on the homepage map. On some devices rotation of the map is possible, so this button is needed!

Fixes # (issue)

1. Show Compass Control on Map, which resets north

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Change Status

- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?

- [ ] `npm test`

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] There are no merge conflicts
