### PR TITLE
Fixed an issue with the VH in the LoginStyle component.

### DIFF
--- a/src/components/Login/LoginContainerStyled.js
+++ b/src/components/Login/LoginContainerStyled.js
@@ -6,8 +6,7 @@ export const StyledLogin = styled.div`
   justify-content: space-between;
   .background-image {
     background-image: url(${statueOfLiberty});
-    width: 55vw;
-    height: 100vh;
+    width: 60vw;
     background-position: center;
     background-size: cover;
   }


### PR DESCRIPTION
# Description
Vh was set to 100 in the loginContainerStyled component, I removed it and tweaked the Vw a bit, I think it looks much better now, no more white space at the bottom, and added some white space at the top of Login container.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Change Status

- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

- [ ] `npm test`

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
