### PR TITLE
Aligns all text on homepage to the left

### DIFF
--- a/src/components/graphs/assets/Legend.css
+++ b/src/components/graphs/assets/Legend.css
@@ -1,5 +1,18 @@
 .graph-legend-wrap {
   margin-bottom: 6%;
-  padding: 20px;
+  padding: 0 0 0 1%;
   border: 1px solid rgba(255, 99, 132, 0.4);
+}
+
+h3.homepage-legend {
+  text-align: left;
+}
+
+li.rank {
+  list-style-type: none;
+  padding: 1% 0 0 0;
+}
+
+p.graph-disclaimer {
+  margin-top: 0;
 }

--- a/src/components/graphs/assets/Legend.js
+++ b/src/components/graphs/assets/Legend.js
@@ -4,28 +4,28 @@ import './Legend.css';
 function Legend() {
   return (
     <div>
-      <h3>Graph Legend</h3>
+      <h3 className="homepage-legend">Graph Legend</h3>
       <p className="graph-legend-wrap">
-        <li>
+        <li className="rank">
           Rank 1 — Officer Presence: Police are present, but no force detected.
           This is not shown on the graph.
         </li>
-        <li>
+        <li className="rank">
           Rank 2 — Empty-hand: Officers use bodily force to gain control of a
           situation. Officers may use grabs, holds, joint locks, punches and
           kicks to restrain an individual.
         </li>
-        <li>
+        <li className="rank">
           Rank 3 — Blunt Force: Officers use less-lethal technologies to gain
           control of a situation. Baton or projectile may be used to immobilize
           a combative person for example.
         </li>
-        <li>
+        <li className="rank">
           Rank 4 — Chemical & Electric: Officers use less-lethal technologies to
           gain control of a situation, such as chemical sprays, projectiles
           embedded with chemicals, or tasers to restrain an individual.
         </li>
-        <li>
+        <li className="rank">
           Rank 5 — Lethal Force: Officers use lethal weapons to gain control of
           a situation.
         </li>

--- a/src/components/timeline/RecentTimeline.css
+++ b/src/components/timeline/RecentTimeline.css
@@ -14,6 +14,25 @@ div.timeline-container {
   box-shadow: 0px 3px 10px rgba(0, 0, 0, 0.08);
 }
 
+h4.cityState {
+  font-weight: normal;
+  padding-bottom: 1%;
+}
+
+h3.card-title {
+  text-align: left;
+  padding-bottom: 1%;
+}
+
+h5.card-force-rank {
+  font-weight: normal;
+  padding-bottom: 2%;
+}
+
+div.card-tags-container {
+  padding-bottom: 2%;
+}
+
 .timeline-button {
   width: 100%;
   font-size: large;

--- a/src/components/timeline/TimelineItems.js
+++ b/src/components/timeline/TimelineItems.js
@@ -5,6 +5,7 @@ import { nanoid } from 'nanoid';
 import { Card, Tag, Popover, Button } from 'antd';
 import { UpOutlined, DownOutlined } from '@ant-design/icons';
 import sourceListHelper from '../../utils/sourceListHelper';
+import './RecentTimeline.css';
 
 export default function TimelineItems({ details }) {
   // the urlDomain function pulls the website name from the string we are getting back from the API, this one cuts off the .com part as well (not currently in use)
@@ -34,11 +35,11 @@ export default function TimelineItems({ details }) {
           <h4 className="cityState">
             {details.city}, {details.state}
           </h4>
-          <h3>{details.title}</h3>
+          <h3 className="card-title">{details.title}</h3>
           {isInfoVisible ? (
             <div>
-              <h5>{details.force_rank}</h5>
-              <div>
+              <h5 className="card-force-rank">{details.force_rank}</h5>
+              <div className="card-tags-container">
                 {details.categories.map(element => (
                   <Tag key={nanoid()}>
                     {element.charAt(0).toUpperCase() + element.slice(1)}

--- a/src/index.css
+++ b/src/index.css
@@ -1219,8 +1219,8 @@ form label {
   .timeline-wrapper {
     margin-top: -20px;
     width: 100%;
-    justify-content: center;
-    align-items: center;
+    /* justify-content: center; */
+    /* align-items: center; */
   }
   .horizontal-graph {
     width: 80%;


### PR DESCRIPTION
# Description
Restyles the timeline and graph area of the homepage. Aligns all text to the left. Removes the graph legend list bullets. Adds padding around the elements in the timeline cards.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Change Status

- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?

- [x] `npm test`

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
