### PR TITLE
Feature/home page scroll down arrow 

### DIFF
--- a/src/components/Stats/Stats.css
+++ b/src/components/Stats/Stats.css
@@ -1,4 +1,3 @@
-
 .stats {
   background-color: var(--blue);
   text-align: center;
@@ -17,7 +16,6 @@
   align-items: center;
   height: 10vh;
 }
-
 
 .stat h2 {
   color: white;
@@ -63,5 +61,61 @@
   .ant-carousel .slick-dots {
     padding-bottom: 13px;
   }
+}
+
+.arrow-container {
+  display: block;
+  width: 100px;
+  height: 100px;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) rotateZ(0deg);
+}
+.arrow-container:hover {
+  cursor: pointer;
+}
+.arrow-container:hover .arrow {
+  top: 50%;
+}
+.arrow-container:hover .arrow:before {
+  transform: translate(-50%, -50%) rotateZ(-30deg);
+}
+.arrow-container:hover .arrow:after {
+  transform: translate(-50%, -50%) rotateZ(30deg);
+}
+.arrow {
+  position: absolute;
+  left: 50%;
+  transition: all 0.4s ease;
+}
+.arrow:before,
+.arrow:after {
+  transition: all 0.4s ease;
+  content: '';
+  display: block;
+  position: absolute;
+  transform-origin: bottom right;
+  background: #fff;
+  width: 4px;
+  height: 50px;
+  border-radius: 10px;
+  transform: translate(-50%, -50%) rotateZ(-45deg);
+}
+.arrow:after {
+  transform-origin: bottom left;
+  transform: translate(-50%, -50%) rotateZ(45deg);
+}
+.arrow:nth-child(1) {
+  opacity: 0.3;
+  top: 35%;
+}
+.arrow:nth-child(2) {
+  opacity: 0.6;
+  top: 55%;
+}
+.arrow:nth-child(3) {
+  opacity: 0.9;
+  top: 75%;
 }
 /*# sourceMappingURL=Stats.css.map */

--- a/src/components/Stats/Stats.css
+++ b/src/components/Stats/Stats.css
@@ -64,10 +64,11 @@
 }
 
 .arrow-container {
+  border: solid red;
   display: block;
-  width: 100px;
+  margin: 0% 0% 0% 50%;
+  width: 30%;
   height: 100px;
-  position: absolute;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%) rotateZ(0deg);

--- a/src/components/Stats/Stats.css
+++ b/src/components/Stats/Stats.css
@@ -63,10 +63,6 @@
   }
 }
 
-html {
-  scroll-behavior: smooth !important;
-}
-
 div.line-break {
   background-color: white;
   width: 109.6%;
@@ -94,9 +90,14 @@ div.line-break {
   font-weight: lighter;
 }
 
+/*arrows scroll behavior*/
+html {
+  scroll-behavior: smooth !important;
+}
+
+/*arrows implementation & animation */
 .arrow-container {
   display: block;
-  /* position: absolute; */
   margin: 1.2% 0% -1% 50%;
   padding: 1.7%;
   height: 30px;
@@ -108,20 +109,25 @@ div.line-break {
 .arrow-container:hover {
   cursor: pointer;
 }
+
 .arrow-container:hover .arrow {
   top: 50%;
 }
+
 .arrow-container:hover .arrow:before {
   transform: translate(-50%, -50%) rotateZ(-30deg);
 }
+
 .arrow-container:hover .arrow:after {
   transform: translate(-50%, -50%) rotateZ(30deg);
 }
+
 .arrow {
   position: absolute;
   left: 50%;
   transition: all 0.4s ease;
 }
+
 .arrow:before,
 .arrow:after {
   transition: all 0.4s ease;
@@ -135,19 +141,25 @@ div.line-break {
   border-radius: 10px;
   transform: translate(-50%, -50%) rotateZ(-45deg);
 }
+
 .arrow:after {
   transform-origin: bottom left;
   transform: translate(-50%, -50%) rotateZ(45deg);
 }
+
 .arrow:nth-child(1) {
   opacity: 0.3;
   top: 35%;
 }
+
 .arrow:nth-child(2) {
   opacity: 0.6;
   top: 55%;
 }
+
 .arrow:nth-child(3) {
   opacity: 0.9;
   top: 75%;
-} /*# sourceMappingURL=Stats.css.map */
+}
+
+/*# sourceMappingURL=Stats.css.map */

--- a/src/components/Stats/Stats.css
+++ b/src/components/Stats/Stats.css
@@ -63,12 +63,44 @@
   }
 }
 
-.arrow-container {
-  border: solid red;
+html {
+  scroll-behavior: smooth !important;
+}
+
+div.line-break {
+  background-color: white;
+  width: 109.6%;
+  padding: 0.25% 0 0 0;
+  margin: 0.5% 0 1% -8%;
+}
+
+.site-layout-background {
+  padding: 2rem;
+  color: white;
+  text-align: center;
+  background: #003767;
+}
+
+#title {
   display: block;
-  margin: 0% 0% 0% 50%;
-  width: 30%;
-  height: 100px;
+  color: white;
+  font-weight: normal;
+  width: 98%;
+}
+
+.more-info {
+  margin: -1.5% 0% 1.2% 0%;
+  color: white;
+  font-weight: lighter;
+}
+
+.arrow-container {
+  display: block;
+  /* position: absolute; */
+  margin: 1.2% 0% -1% 50%;
+  padding: 1.7%;
+  height: 30px;
+  width: 103%;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%) rotateZ(0deg);
@@ -99,7 +131,7 @@
   transform-origin: bottom right;
   background: #fff;
   width: 4px;
-  height: 50px;
+  height: 30px;
   border-radius: 10px;
   transform: translate(-50%, -50%) rotateZ(-45deg);
 }
@@ -118,5 +150,4 @@
 .arrow:nth-child(3) {
   opacity: 0.9;
   top: 75%;
-}
-/*# sourceMappingURL=Stats.css.map */
+} /*# sourceMappingURL=Stats.css.map */

--- a/src/components/Stats/Stats.js
+++ b/src/components/Stats/Stats.js
@@ -48,13 +48,13 @@ const Stats = () => {
 
   return (
     <Content Dark="On" type="Primary">
-      <a href="#" className="arrow-container">
-        <div className="arrow"></div>
-        <div className="arrow"></div>
-        <div className="arrow"></div>
-      </a>
       <div className="site-layout-background" style={contentStyle}>
-        <Title style={{ color: 'white', fontWeight: 'normal' }}>
+        <a href="#title" className="arrow-container">
+          <div className="arrow"></div>
+          <div className="arrow"></div>
+          <div className="arrow"></div>
+        </a>
+        <Title id="title" style={{ color: 'white', fontWeight: 'normal' }}>
           Blue Witness Statistics
         </Title>
         <Paragraph style={{ color: 'white' }}>

--- a/src/components/Stats/Stats.js
+++ b/src/components/Stats/Stats.js
@@ -1,51 +1,11 @@
-import React, { useEffect, useState } from 'react';
-import { useSelector } from 'react-redux';
-import { Layout, Button, Typography } from 'antd';
-import { Link } from 'react-router-dom';
+import React from 'react';
+import { Layout, Typography } from 'antd';
 import './Stats.css';
 
-const { Title, Paragraph } = Typography;
+const { Title } = Typography;
 const { Content } = Layout;
 
 const Stats = () => {
-  const [gasAndSpray, setGasAndSpray] = useState(0);
-  const [arrests, setArrests] = useState(0);
-  const [numCities, setNumCities] = useState(0);
-  // Banner Style settings
-  const contentStyle = {
-    padding: '3rem',
-    color: 'white',
-    textAlign: 'center',
-    background: '#003767',
-  };
-  // Documents the reports of incidents and sores them in a state in which it can be displayed on the Banner
-  const dataList = useSelector(state => Object.values(state.incident.data));
-
-  useEffect(() => {
-    let newCat = [];
-
-    const newCategories = dataList.map((gas, index) => {
-      return newCat.push(gas.categories.flat());
-    });
-    let pepperSpray = newCat.flat().filter((filters, index) => {
-      return filters === 'pepper-spray';
-    });
-    let tearGas = newCat.flat().filter((filters, index) => {
-      return filters === 'tear-gas';
-    });
-    let totalCities = dataList.map(city => {
-      return city.city;
-    });
-    let reducedCities = [...new Set(totalCities)];
-    let totalArrests = newCat.flat().filter((filters, index) => {
-      return filters === 'arrest';
-    });
-
-    setGasAndSpray(pepperSpray.length + tearGas.length);
-    setArrests(totalArrests.length);
-    setNumCities(reducedCities.length);
-  }, [dataList]);
-
   return (
     <Content className="BW-container" Dark="On" type="Primary">
       <div className="site-layout-background">
@@ -57,21 +17,6 @@ const Stats = () => {
         </a>
         <div className="line-break"></div>
         <Title id="title">Blue Witness Statistics</Title>
-        {/* <Paragraph style={{ color: 'white' }}>
-          {dataList.length} incidents of police use of force. {gasAndSpray} uses
-          of pepper-spray or tear-gas. {numCities} cities across the United
-          States.
-        </Paragraph>
-        <Button style={{ margin: '.5rem' }} shape="round" ghost>
-          <Link to="/incident-reports">Incident Reports</Link>
-        </Button>
-        <Button
-          style={{ marginLeft: '3rem', padding: '0 3rem' }}
-          shape="round"
-          ghost
-        >
-          <Link to="/about">About</Link>
-        </Button> */}
       </div>
     </Content>
   );

--- a/src/components/Stats/Stats.js
+++ b/src/components/Stats/Stats.js
@@ -47,17 +47,17 @@ const Stats = () => {
   }, [dataList]);
 
   return (
-    <Content Dark="On" type="Primary">
-      <div className="site-layout-background" style={contentStyle}>
+    <Content className="BW-container" Dark="On" type="Primary">
+      <div className="site-layout-background">
+        <p className="more-info">Click arrows for more infomation</p>
         <a href="#title" className="arrow-container">
           <div className="arrow"></div>
           <div className="arrow"></div>
           <div className="arrow"></div>
         </a>
-        <Title id="title" style={{ color: 'white', fontWeight: 'normal' }}>
-          Blue Witness Statistics
-        </Title>
-        <Paragraph style={{ color: 'white' }}>
+        <div className="line-break"></div>
+        <Title id="title">Blue Witness Statistics</Title>
+        {/* <Paragraph style={{ color: 'white' }}>
           {dataList.length} incidents of police use of force. {gasAndSpray} uses
           of pepper-spray or tear-gas. {numCities} cities across the United
           States.
@@ -71,7 +71,7 @@ const Stats = () => {
           ghost
         >
           <Link to="/about">About</Link>
-        </Button>
+        </Button> */}
       </div>
     </Content>
   );

--- a/src/components/Stats/Stats.js
+++ b/src/components/Stats/Stats.js
@@ -2,6 +2,8 @@ import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { Layout, Button, Typography } from 'antd';
 import { Link } from 'react-router-dom';
+import './Stats.css';
+
 const { Title, Paragraph } = Typography;
 const { Content } = Layout;
 
@@ -46,6 +48,11 @@ const Stats = () => {
 
   return (
     <Content Dark="On" type="Primary">
+      <a href="#" className="arrow-container">
+        <div className="arrow"></div>
+        <div className="arrow"></div>
+        <div className="arrow"></div>
+      </a>
       <div className="site-layout-background" style={contentStyle}>
         <Title style={{ color: 'white', fontWeight: 'normal' }}>
           Blue Witness Statistics


### PR DESCRIPTION
# Description
Implements the arrows to prompt the user to the bottom of the page. Adds a white line break between the arrows and the Blue Witness title. Removes the code about the statistics and the two buttons that were previously used for the banner since it is not necessary anymore.
Co-Author: @StephanieEnciso 

Fixes # (issue)


## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)


## Change Status

- [ ] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

- [ ] `npm test`

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
