### PR TITLE
fixes graph page syntax

### DIFF
--- a/src/components/graphs/GraphContainer.js
+++ b/src/components/graphs/GraphContainer.js
@@ -206,7 +206,7 @@ const GraphContainer = () => {
               Total incident reports identified by our data collection methods
               by state
             </h2>
-            <h4>April 2020 to Present</h4>
+            <h4>April 2020 - Present</h4>
             <BarGraph count={barCounts} />
           </section>
         ) : null}
@@ -217,7 +217,7 @@ const GraphContainer = () => {
                 Prevalence of Force Ranks as identified by our data collection
                 methods
               </h2>
-              <h4>April 2020 to Present</h4>
+              <h4>April 2020 - Present</h4>
               <div className="pie-holder">
                 <div className="pie">
                   <PieGraph data={filtered} />


### PR DESCRIPTION
Naming: feature/graph-page-syntax/daniel-vargas

Reviewers: minimum 2

Description:
What is the motivation for changes?

The motivation behind these changes were to make the syntax of the graphs page more consistent
What specific changes were made?

All date ranges now use a hyphen to join the months instead of 'to'. For example,  'June to July' is now 'June - July'
Submitter Checklist:

[x] Small scope (1-2 components)
[x] Not too many concerns in a single commit
[x] Remove extraneous comments (code in comments), print statements, to-dos, console.logs, extra fluff
[x] Atomic, descriptive commit messages
[x] Consistent formatting
Reviewer Checklist:

[  ] Small scope (1-2 components)
[  ] Comments, print statements, to-dos, console.logs, extra fluff were removed
[  ] Give feedback no matter what conversations happened elsewhere, document here
[  ] Comment on the line of code itself (blue plus box) in files changed tab
