### PR TITLE
styling fix on incident reports page

### DIFF
--- a/src/components/incidents/Incidents.css
+++ b/src/components/incidents/Incidents.css
@@ -3,10 +3,11 @@
   width: 100%;
   margin: auto;
   margin-top: 2rem;
+  max-width: 1550px;
 }
 .incident-reports-page h1 {
   font-size: 1.5rem;
-  text-align: center;
+  text-align: flex-start;
 }
 .export-form {
   text-align: left;
@@ -140,8 +141,7 @@ span.ant-tag.ant-tag-checkable-checked:hover {
 .export-form {
   display: flex;
   flex-direction: column;
-  justify-content: center;
-  align-items: center;;
+  align-items: left;;
 }
 .title-container{
   width: 35%;


### PR DESCRIPTION
# Description
- Left aligned elements on incident reports page as per Franks feedback.
- Set max width on incident reports page so the page doesn't stretch indefinitely on large screens.

Fixes #
- [x] Bug fix (non-breaking change which fixes an issue)

## Change Status

- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?

All tests pass

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
