### PR TITLE
Feature/navmenu collapse icon/leon nasswetter

### DIFF
--- a/src/components/NavBar/NavBar.js
+++ b/src/components/NavBar/NavBar.js
@@ -30,7 +30,11 @@ const NavBar = () => {
       <Menu
         className="menu"
         mode="horizontal"
-        overflowedIndicator={<MenuOutlined />}
+        overflowedIndicator={
+          <MenuOutlined
+            style={{ margin: '0', fontSize: '1.5rem', paddingTop: '14px' }}
+          />
+        }
       >
         <Space></Space>
         <Menu.Item key="1">

--- a/src/components/NavBar/NavBar.js
+++ b/src/components/NavBar/NavBar.js
@@ -7,7 +7,7 @@ import lambdaLogo from '../../assets/LambdaAssets/Built by lambda.png';
 import IncidentFocus from '../Home/Map/IncidentFocus';
 // import { useOktaAuth } from '@okta/okta-react';
 import { Layout, Menu, Sider, Input, Space, Typography } from 'antd';
-import { SearchOutlined } from '@ant-design/icons';
+import { MenuOutlined } from '@ant-design/icons';
 import './nav.css';
 const { Search } = Input;
 
@@ -27,7 +27,11 @@ const NavBar = () => {
           <img className="hrf-logo" alt="hrf-logo" src={logo} />
         </Link>
       </div>
-      <Menu className="menu" mode="horizontal">
+      <Menu
+        className="menu"
+        mode="horizontal"
+        overflowedIndicator={<MenuOutlined />}
+      >
         <Space></Space>
         <Menu.Item key="1">
           <Link className="menu-link" to="/">

--- a/src/components/NavBar/nav.css
+++ b/src/components/NavBar/nav.css
@@ -20,7 +20,7 @@
   background: #003767;
   padding-top: 1rem;
   width: 55%;
-  margin-top: -.2rem;
+  margin-top: -0.2rem;
   margin-right: 1rem;
   font-size: 1rem;
   height: 1rem;
@@ -32,11 +32,22 @@
   color: white;
 }
 
-.ant-menu-item-selected  {
-  background-color:  #ffffff00 !important;
+.ant-menu-item-selected {
+  background-color: #ffffff00 !important;
 }
 
 .ant-menu-submenu-title span {
   color: #fff;
 }
 
+/* Fix for bottom border of nav-menu collapsed icon (removing it will somehow still display black border when leaving hover state */
+.ant-menu-horizontal:not(.ant-menu-dark) > .ant-menu-item:hover,
+.ant-menu-horizontal:not(.ant-menu-dark) > .ant-menu-submenu:hover,
+.ant-menu-horizontal:not(.ant-menu-dark) > .ant-menu-item-active,
+.ant-menu-horizontal:not(.ant-menu-dark) > .ant-menu-submenu-active,
+.ant-menu-horizontal:not(.ant-menu-dark) > .ant-menu-item-open,
+.ant-menu-horizontal:not(.ant-menu-dark) > .ant-menu-submenu-open,
+.ant-menu-horizontal:not(.ant-menu-dark) > .ant-menu-item-selected,
+.ant-menu-horizontal:not(.ant-menu-dark) > .ant-menu-submenu-selected {
+  border-color: rgba(0, 0, 0, 0);
+}


### PR DESCRIPTION
# Description

As suggested by Frank in product review (7/22), switches default icon for collapsed nav-menu from 3 dots to more common 3 lines/burger menu. 

## Burger (new)
![burger](https://user-images.githubusercontent.com/75326573/126884469-c81b29de-e253-40f4-ad79-d2175ff1d026.JPG)
## Dots (old)
![dots](https://user-images.githubusercontent.com/75326573/126884474-ac9e4047-7a7e-4ba9-ae0e-cb065a87a731.JPG)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Change Status

- [x] Complete, tested, ready to review and merge
