### PR TITLE
lined search box with other links on graphs page header

### DIFF
--- a/src/components/graphs/pagination/Pagination.css
+++ b/src/components/graphs/pagination/Pagination.css
@@ -4,7 +4,7 @@
   display: flex;
   -webkit-box-pack: justify;
       -ms-flex-pack: justify;
-          justify-content: space-between;
+          justify-content: space-around;
 
 }
 
@@ -65,7 +65,7 @@
   margin-right: 8px;
 }
 
-@media screen and (max-width: 800px) {
+@media screen and (max-width: 880px) {
   .link-container .graph-buttons .link-item .text {
     display: none;
   }
@@ -104,4 +104,18 @@
 
 .search-bar-container{
   margin: 0 6%;
+}
+
+.link-container{
+  width: 75%;
+}
+.graph-buttons{
+  height: 100%;
+}
+.graph-buttons-container{
+  width: 75%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
 }

--- a/src/components/graphs/pagination/Pagination.js
+++ b/src/components/graphs/pagination/Pagination.js
@@ -3,7 +3,7 @@ import React from 'react';
 // Search Bar
 import SearchBar from '../searchbar/SearchBar';
 
-import "./Pagination.css";
+import './Pagination.css';
 
 import {
   LineChartOutlined,
@@ -65,9 +65,11 @@ const Pagination = ({ setGraph, setUsState, filtered }) => {
 
   return (
     <nav style={{ marginTop: '1rem' }} className="link-container">
-      <ul className="graph-buttons">
-        {filtered.length > 0 ? generateButtons(onClick) : null}
-      </ul>
+      <div className="graph-buttons-container">
+        <ul className="graph-buttons">
+          {filtered.length > 0 ? generateButtons(onClick) : null}
+        </ul>
+      </div>
       <div className="search-bar-container">
         <SearchBar setUsState={setUsState} className="search-bar" />
       </div>


### PR DESCRIPTION
# Description
better aligns search box with other links on graph page header

Before
![Screenshot 2021-07-26 101530](https://user-images.githubusercontent.com/75264076/127006708-c3a20538-76b3-4792-853b-4fc396d70ea7.png)
After
![Screenshot 2021-07-26 102731](https://user-images.githubusercontent.com/75264076/127006729-0e58a8c5-0791-4669-a36f-8de7843ec9bf.png)




## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)


## Change Status

- [x] Complete, tested, ready to review and merge


# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
