### PR TITLE
removes width property on body causing huge white bar on right side of screen

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1171,13 +1171,6 @@ form label {
 }
 
 @media (max-width: 800px) {
-  body {
-    width: 375px;
-  }
-
-  /* .nav-container div {
-    width: 90%;
-  } */
 
   .mapDiv {
     width: 100%;


### PR DESCRIPTION
# Description

Removes css that set bodywidth to 375px at 800px screen that was causing huge white bar on right side. This somehow was only affecting the hosted version and not local versions. Amazing catch by @BradleyHubbs 

Adding Brads screenshots for clarification. Same code, top is hosted, bottom local. Removing propterty shown in most bottom screenshot solves the issue. 
![Screenshot 2021-07-26 121714](https://user-images.githubusercontent.com/75326573/127030765-803fd6b7-7ad8-4e98-83cf-07c76bb1ea68.png)
![Screenshot 2021-07-26 121624](https://user-images.githubusercontent.com/75326573/127030772-9d1061b4-7418-473f-a0f7-7f49bf4b9f70.png)
![awdawd](https://user-images.githubusercontent.com/75326573/127030981-30c750b4-1ac4-4b5b-b2df-c3ac7499138e.JPG)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Change Status

- [x] Complete, tested, ready to review and merge