### PR TITLE
Removes Meet Our Bot section from about page.

### DIFF
--- a/src/components/about/About.js
+++ b/src/components/about/About.js
@@ -102,7 +102,17 @@ const About = () => {
             </p>
           </div>
           <div className="about-bot-container">
-            <h2>Our Twitter Bot</h2>
+            <h2>
+              Our Twitter Bot
+              <span>
+                {' '}
+                <img
+                  className="twitter-icon"
+                  src="https://img.icons8.com/android/24/ffffff/twitter.png"
+                  alt="twitter icon"
+                />
+              </span>
+            </h2>
             <p>
               The goal of the Twitterbot on the Blue Witness project is to
               adequately scrape twitter for reports of incidents of police
@@ -119,14 +129,6 @@ const About = () => {
               you'd like to know more, feel free to reach out to HRF on our
               contact page.
             </p>
-            <div className="twitter-icon-container">
-              <img
-                className="twitter-icon"
-                src="https://img.icons8.com/android/24/ffffff/twitter.png"
-                alt="twitter icon"
-              />
-              <span className="bot-css">Meet The Bot</span>
-            </div>
           </div>
         </div>
         <div className="inside-bottom-container lambda-credits-container">


### PR DESCRIPTION
# Description
Removes Meet Our Bot section from about page. Places Twitter logo beside Our Twitter Bot text.



Fixes # (issue)
A dead link that would require significant work to make functional.

## Type of change
Front End / Design

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)

## Change Status

- [ x ] Complete, tested, ready to review and merge
- Visually Tested/inspected.
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?
Visually, by resizing the div to make sure there's no CSS issues caused by removing the text.

- [ ] `npm test`

# Checklist

- [ x ] My code follows the style guidelines of this project
- [ x ] I have performed a self-review of my own code
- [ x ] My code has been reviewed by at least one peer
- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ x ] I have made corresponding changes to the documentation
- [ x ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ x ] There are no merge conflicts

>>> Screenshot of Change
![Capture](https://user-images.githubusercontent.com/73312607/128420282-abfe35b6-d721-4b79-8e00-38c0b4d8a761.PNG)
