### PR TITLE
Fixed bug occuring from node_module

### DIFF
--- a/src/components/timeline/TimelineItems.css
+++ b/src/components/timeline/TimelineItems.css
@@ -110,6 +110,10 @@ div.timeline-container {
     position: relative;
     height: 32px;
   }
+  .entry .title:before{
+    display: none;
+  }
+
   .entry:before {
     content: "";
     position: absolute;
@@ -196,6 +200,9 @@ div.timeline-container {
       float: left;
       width: 100%;
     }
+    .entry .title:before{
+      display: none;
+    }
     .timeline-item-date {
       background: none;
       clip-path: polygon(5% 0%, 100% 0%, 100% 100%, 5% 100%, 0% 50%);
@@ -225,11 +232,17 @@ div.timeline-container {
     .timeline-wrapper {
       width: 40vw;
     }
+    .entry .title:before{
+      display: none;
+    }
   }
   
   @media (max-width: 1980px) {
     .timeline-wrapper {
       width: 45vw;
+    }
+    .entry .title:before{
+      display: none;
     }
   }
   
@@ -237,10 +250,16 @@ div.timeline-container {
     .timeline-wrapper {
       width: 55vw;
     }
+    .entry .title:before{
+      display: none;
+    }
   }
   
   @media (max-width: 1280px) {
     .timeline-wrapper {
       width: 55vw;
+    }
+    .entry .title:before{
+      display: none;
     }
   }


### PR DESCRIPTION
# Description![image](https://user-images.githubusercontent.com/75689512/129066299-e8935e5e-0e29-4fb2-9a2c-bb5586dd6cd6.png)
Fixes # (issue)

The styling in the nodeModules was creating a second dot for each event on the vertical timeline so I implemented code to overwrite it in the src code. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Change Status

- [ ] Complete, tested, ready to review and merge


# How Has This Been Tested?

- [x] `npm test`

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
