### PR TITLE
adds hover style of white/underline to nav links

### DIFF
--- a/src/components/NavBar/nav.css
+++ b/src/components/NavBar/nav.css
@@ -32,6 +32,11 @@
   color: white;
 }
 
+.ant-menu-horizontal > .ant-menu-item a:hover {
+  color: white;
+  border-bottom: solid 1.1px white;
+}
+
 .ant-menu-item-selected {
   background-color: #ffffff00 !important;
 }


### PR DESCRIPTION
# Description

![nav_before](https://user-images.githubusercontent.com/79304010/129276542-f854f6f9-6a8f-473b-b180-d05812ee57bd.PNG)

Fixes # (issue)

The Home, Incident Reports, Graph, and About links in the navbar had a hover feature that changed the text color to dark blue. This made it harder to see with the dark blue background of the navbar. I changed the hover style of the text to a white underline instead. 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Change Status

- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?

- [x] `npm test`

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
