### PR TITLE
Centers arrow on 'search recent reports' drop down

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -362,6 +362,10 @@ div.HeaderInfo {
   /* search on top of map */
 }
 
+.search-header > div > span {
+  top: 16px;
+}
+
 .map-menu {
   margin-top: 1rem;
   margin-right: 1rem;


### PR DESCRIPTION
# Description

![recent_reports](https://user-images.githubusercontent.com/79304010/130138449-786fda8c-d0f4-4e5e-8523-07d346fbd8d8.PNG)

Fixes # (issue)

The drop down arrow on the 'search recent reports' was not aligned. Made changes to styling in order to center the arrow. Verified style stayed consistent at various screen widths. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Change Status

- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?

- [x] `npm test`

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
