### PR TITLE
changed force_rank filter values to match data

### DIFF
--- a/src/components/graphs/bargraph/HorizontalBar.js
+++ b/src/components/graphs/bargraph/HorizontalBar.js
@@ -49,22 +49,22 @@ const Horizontalbar = () => {
 
   useEffect(() => {
     const emptyHandTotal = dataList.filter((x, index) => {
-      return x.force_rank === 'Rank 2 - Empty-hand';
+      return x.force_rank === 'Rank 2';
     }).length;
     setEmptyHand(emptyHandTotal);
 
     const bluntForceTotal = dataList.filter((x, index) => {
-      return x.force_rank === 'Rank 3 - Blunt Force';
+      return x.force_rank === 'Rank 3';
     }).length;
     setBluntForce(bluntForceTotal);
 
     const chemicalElectricTotal = dataList.filter((x, index) => {
-      return x.force_rank === 'Rank 4 - Chemical & Electric';
+      return x.force_rank === 'Rank 4';
     }).length;
     setChemicalElectric(chemicalElectricTotal);
 
     const lethalforceMethodsTotal = dataList.filter((x, index) => {
-      return x.force_rank === 'Rank 5 - Lethal Force';
+      return x.force_rank === 'Rank 5';
     }).length;
     setLethalForce(lethalforceMethodsTotal);
   }, [dataList]);


### PR DESCRIPTION
# Description

The graph on the front page that displays the number of incident reports gathered was blank and showed no data. The values it was using to filter incidents by rank were incorrect. They've been updated to match the values in the data, so the graph can render properly.

![graph before fix](https://res.cloudinary.com/hvvmlo7os/image/upload/v1630606483/blue-watch/graph-before_waf1jm.png)

![graph after fix](https://res.cloudinary.com/hvvmlo7os/image/upload/v1630606481/blue-watch/graph-after_wbzoxb.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Change Status

- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?

Using the pre-existing test suite.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] There are no merge conflicts
