### PR TITLE
Bug/force rank

### DIFF
--- a/handoff.md
+++ b/handoff.md
@@ -1,0 +1,31 @@
+# Welcome labs_38 Frontend Devs!
+
+##### This file is meant to help clear things up and provide a good starting direction for you because, I think I speak for all of labs_37 when I say,  we know how overwhelming this can be at first.  If you get too stress or have any questions and the answer is not in here, know that you can reach out to any member of the previous cohort on slack for help.  Good luck this month!  
+
+
+### Quick Notes
+- We are using ant design for some styling/components.  https://ant.design/docs/react/introduce
+- Full walkthrough of the data flow for the form feature we implemented (including bugs to be fixed) https://youtu.be/dRBYRQ5QpoI
+- There may be CSS located in the node_modules file because of certain libraries being used...  If you want to change one of these components' styling, you may have to find the CSS in the Node_modules that is associated with it then overwrite that CSS by coding it in the src code.  node_modules is in the .gitignore file so any changes you make there will be ignored when you push your code.  If you have more questions please please please reach out to one of us because this concept was a bit weird and annoying to implement at first.
+- Testing coverage is not that great currently, that can always be improved upon
+- Redux is set up but hardly being used, feel free to convert some components to be utilizing this
+- If you UI/UX guys are feelin SPICY, then check this out https://d3js.org/. Could be a cool way to display the data rather than the current map we have.  Just make sure to let the stakeholder know before you actually implement it if you choose to do so
+
+
+### Current issues
+- src/components/form/TwitterForm.js needs to be using 'tweet_id' rather than 'incident_id' for the GET request on line 29 (communicate with Web BE about how to implement this)
+- src/components/form/TwitterForm.js We are having an issue populating the "Date" field upon initial render
+- src/components/form/TwitterForm.js display some sort of error/success  message upon form submission (right now all we are doing is routing the user back to the homepage upon success line 84)
+- "Rank" sort function on https://a.humanrightsfirst.dev/incident-reports needs to be fixed
+- Most all of the sort functions are not functional on the Admin Dashboard 
+
+<details>
+<summary>motivation</summary>
+
++ https://open.spotify.com/playlist/37i9dQZF1DXbXD9pMSZomS?si=5fdc301a09704727
++ https://open.spotify.com/album/340MjPcVdiQRnMigrPybZA?si=UWtRRR0xQZiYUIGSHjdtVw&dl_branch=1
++ https://i.redd.it/eqntkqfehnj01.jpg
++ https://www.thecoderpedia.com/wp-content/uploads/2020/06/Programming-Memes-Programmer-while-sleeping.jpg?x67166
++ https://iq.opengenus.org/content/images/2019/12/semicolon.jpg
+
+</details>

--- a/src/components/AdminDashboard/AddIncident.js
+++ b/src/components/AdminDashboard/AddIncident.js
@@ -167,18 +167,18 @@ const AddIncident = props => {
           <br />
           <select onChange={handleChange} name="force_rank">
             <option value="">--Select One--</option>
-            <option value="Rank 0 - No Police Presence">
+            <option value="Rank 0">
               Rank 0 - No Police Presence
             </option>
-            <option value="Rank 1 - Police Presence">
+            <option value="Rank 1">
               Rank 1 - Police Presence
             </option>
-            <option value="Rank 2 - Empty-hand">Rank 2 - Empty-hand</option>
-            <option value="Rank 3 - Blunt Force">Rank 3 - Blunt Force</option>
-            <option value="Rank 4 - Chemical &amp; Electric">
+            <option value="Rank 2">Rank 2 - Empty-hand</option>
+            <option value="Rank 3">Rank 3 - Blunt Force</option>
+            <option value="Rank 4">
               Rank 4 - Chemical &amp; Electric
             </option>
-            <option value="Rank 5 - Lethal Force">Rank 5 - Lethal Force</option>
+            <option value="Rank 5">Rank 5 - Lethal Force</option>
           </select>
         </label>
         <br />

--- a/src/components/AdminDashboard/CompleteIncident.js
+++ b/src/components/AdminDashboard/CompleteIncident.js
@@ -167,18 +167,18 @@ const CompleteIncident = props => {
               name="force_rank"
               value={formValues.force_rank}
             >
-              <option value="Rank 0 - No Police Presence">
+              <option value="Rank 0">
                 Rank 0 - No Police Presence
               </option>
-              <option value="Rank 1 - Police Presence">
+              <option value="Rank 1">
                 Rank 1 - Police Presence
               </option>
-              <option value="Rank 2 - Empty-hand">Rank 2 - Empty-hand</option>
-              <option value="Rank 3 - Blunt Force">Rank 3 - Blunt Force</option>
-              <option value="Rank 4 - Chemical &amp; Electric">
+              <option value="Rank 2">Rank 2 - Empty-hand</option>
+              <option value="Rank 3">Rank 3 - Blunt Force</option>
+              <option value="Rank 4">
                 Rank 4 - Chemical &amp; Electric
               </option>
-              <option value="Rank 5 - Lethal Force">
+              <option value="Rank 5">
                 Rank 5 - Lethal Force
               </option>
             </select>

--- a/src/components/form/TwitterForm.js
+++ b/src/components/form/TwitterForm.js
@@ -106,15 +106,15 @@ const TwitterForm = () => {
             value={data.force_rank}
           >
             <Option value=""></Option>
-            <Option value="Rank 1 - Police Presence">
+            <Option value="Rank 1">
               Rank 1 - Police Presence
             </Option>
-            <Option value="Rank 2 - Empty Hand">Rank 2 - Empty-hand</Option>
-            <Option value="Rank 3 - Blunt Force">Rank 3 - Blunt Force</Option>
-            <Option value="Rank 4 - Chemical & Electric">
+            <Option value="Rank 2">Rank 2 - Empty-hand</Option>
+            <Option value="Rank 3">Rank 3 - Blunt Force</Option>
+            <Option value="Rank 4">
               Rank 4 - Chemical & Electric
             </Option>
-            <Option value="Rank 5 - Lethal Force">Rank 5 - Lethal Force</Option>
+            <Option value="Rank 5">Rank 5 - Lethal Force</Option>
           </Select>
         </label>
         <br></br>

--- a/src/components/graphs/bargraph/HorizontalBar.js
+++ b/src/components/graphs/bargraph/HorizontalBar.js
@@ -49,22 +49,22 @@ const Horizontalbar = () => {
 
   useEffect(() => {
     const emptyHandTotal = dataList.filter((x, index) => {
-      return x.force_rank === 'Rank 2 - Empty-hand';
+      return x.force_rank === 'Rank 2';
     }).length;
     setEmptyHand(emptyHandTotal);
 
     const bluntForceTotal = dataList.filter((x, index) => {
-      return x.force_rank === 'Rank 3 - Blunt Force';
+      return x.force_rank === 'Rank 3';
     }).length;
     setBluntForce(bluntForceTotal);
 
     const chemicalElectricTotal = dataList.filter((x, index) => {
-      return x.force_rank === 'Rank 4 - Chemical & Electric';
+      return x.force_rank === 'Rank 4';
     }).length;
     setChemicalElectric(chemicalElectricTotal);
 
     const lethalforceMethodsTotal = dataList.filter((x, index) => {
-      return x.force_rank === 'Rank 5 - Lethal Force';
+      return x.force_rank === 'Rank 5';
     }).length;
     setLethalForce(lethalforceMethodsTotal);
   }, [dataList]);

--- a/src/components/graphs/piegraph/PieGraph.js
+++ b/src/components/graphs/piegraph/PieGraph.js
@@ -20,23 +20,23 @@ const getTypesOfForce = data => {
       //   incrementor(incident, 'Uncategorized', types);
       //   break;
 
-      case 'Rank 1 - Officer Presence':
+      case 'Rank 1':
         incrementor(incident, 'Officer Presence', types);
         break;
 
-      case 'Rank 2 - Empty-hand':
+      case 'Rank 2':
         incrementor(incident, 'Empty Hand', types);
         break;
 
-      case 'Rank 3 - Blunt Force':
+      case 'Rank 3':
         incrementor(incident, 'Blunt Force', types);
         break;
 
-      case 'Rank 4 - Chemical & Electric':
+      case 'Rank 4':
         incrementor(incident, 'Chemical & Electric', types);
         break;
 
-      case 'Rank 5 - Lethal Force':
+      case 'Rank 5':
         incrementor(incident, 'Lethal Force', types);
         break;
 

--- a/src/components/incidents/Incidents.js
+++ b/src/components/incidents/Incidents.js
@@ -25,11 +25,11 @@ import { CSVLink } from 'react-csv'; // helper for export CSV from current State
 import { ConsoleSqlOutlined } from '@ant-design/icons';
 
 let ranks = [
-  'Rank 1 - Police Presence',
-  'Rank 2 - Empty-hand',
-  'Rank 3 - Blunt Force',
-  'Rank 4 - Chemical & Electric',
-  'Rank 5 - Lethal Force',
+  'Rank 1',
+  'Rank 2',
+  'Rank 3',
+  'Rank 4',
+  'Rank 5',
 ];
 
 const { RangePicker } = DatePicker;

--- a/src/utils/mockStoreData.js
+++ b/src/utils/mockStoreData.js
@@ -34,7 +34,7 @@ const incidentsData = [
     desc:
       "Down the street from the Portland ICE facility, a police officer pushes protesters back. The officer passes one protester who then appears to turn on their phone's flashlight. The officer doubles back and pepper sprays the individual.",
     categories: ['less-lethal', 'pepper-spray', 'protester', 'spray'],
-    force_rank: 'Rank 4 - Chemical & Electric',
+    force_rank: 'Rank 4',
   },
   {
     id: 1320,
@@ -50,7 +50,7 @@ const incidentsData = [
     desc:
       'As the curfew approached outside the Brooklyn Center precinct, a protester can be seeing waving a sign several feet away from officers who are huddled behind a chain link fence. One officer fires a less-lethal projectile at the protester, striking them in the foot. There is no evident provocation.',
     categories: ['less-lethal', 'projectile', 'protester', 'shoot'],
-    force_rank: 'Rank 5 - Lethal Force',
+    force_rank: 'Rank 5',
   },
   {
     id: 1330,
@@ -79,7 +79,7 @@ const incidentsData = [
       'shove',
       'tackle',
     ],
-    force_rank: 'Rank 1 - Police Presence',
+    force_rank: 'Rank 1',
   },
   {
     id: 1327,
@@ -105,7 +105,7 @@ const incidentsData = [
       'shove',
       'tackle',
     ],
-    force_rank: 'Rank 2 - Empty-hand',
+    force_rank: 'Rank 2',
   },
   {
     id: 1323,
@@ -121,7 +121,7 @@ const incidentsData = [
     desc:
       'Police and protesters face off on opposite sides of a barricade. Police discharge pepper spray in a wide berth, targeting protesters who step towards them in particular. It is unclear what instigated this incident, although one protester does appear to be trying to recover a red umbrella on the ground.',
     categories: ['less-lethal', 'pepper-spray', 'protester', 'spray'],
-    force_rank: 'Rank 4 - Chemical & Electric',
+    force_rank: 'Rank 4',
   },
   {
     id: 1328,
@@ -143,7 +143,7 @@ const incidentsData = [
     desc:
       'Police arrested a protester near Jefferson Square Park. During the arrest, police tackled the protester to the ground and punched him repeatedly to subdue him. The protester was allegedly flexing his arms, making it difficult for officers to handcuff him.',
     categories: ['arrest', 'protester', 'punch', 'strike'],
-    force_rank: 'Rank 2 - Empty-hand',
+    force_rank: 'Rank 2',
   },
   {
     id: 1309,
@@ -162,7 +162,7 @@ const incidentsData = [
     desc:
       'During a protest regarding the ferries on the island of Culebra, Puerto Rico, protesting kayakers were rammed by a police boat and knocked into the water. Police then hauled the kayak into their boat, leaving the protesters treading water.',
     categories: ['boat', 'protester'],
-    force_rank: 'Rank 1 - Police Presence',
+    force_rank: 'Rank 1',
   },
   {
     id: 1307,
@@ -193,7 +193,7 @@ const incidentsData = [
       'tackle',
       'zip-tie',
     ],
-    force_rank: 'Rank 3 - Blunt Force',
+    force_rank: 'Rank 3',
   },
   {
     id: 1308,
@@ -220,7 +220,7 @@ const incidentsData = [
       'rubber-bullet',
       'shoot',
     ],
-    force_rank: 'Rank 4 - Chemical & Electric',
+    force_rank: 'Rank 4',
   },
 ];
 


### PR DESCRIPTION
# Description

[Explanation video](https://www.loom.com/share/8a6828d078b1460eab50cd94b8c3afc9)

This pull request is to fix inconsistent values for the "force_rank" property on incident data.

In the existing incident data, values for force_rank look like this:
```force_rank: "Rank 4"```

However, many of the components in the front-end were expecting values that looked like this:
```force_rank: "Rank 4 - Chemical & Electric"```

The following components were affected by this inconsistency:
* The bar graph on the front page
* The missing pie graph on the Graph page
* Incident filtering on the Incident Reports page
* Edit incident
* Add incident
* Twitter form

Any usage of the longer force_rank value throughout the front-end project has been updated to use the shorter form that the incident data currently uses.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Change Status

- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?

- [x] `npm test`

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
