### PR TITLE
Got Add Incident Modal to Appear When Clicking Create Incident 

### DIFF
--- a/src/components/AdminDashboard/AdminDashboard.js
+++ b/src/components/AdminDashboard/AdminDashboard.js
@@ -301,6 +301,32 @@ const AdminDashboard = () => {
               toggleAddIncident={toggleAddIncident}
               listType={listType}
             />
+            {adding ? (
+              <AddIncident
+                setPageNumber={setPageNumber}
+                getData={getData}
+                setAdding={setAdding}
+              />
+            ) : (
+              <Incidents
+                confirmApprove={confirmApprove}
+                confirmReject={confirmReject}
+                confirmApproveHandler={confirmApproveHandler}
+                confirmRejectHandler={confirmRejectHandler}
+                approveAndRejectHandler={approveAndRejectHandler}
+                confirmCancel={confirmCancel}
+                setSelected={setSelected}
+                selected={selected}
+                selectAll={selectAll}
+                allSelected={allSelected}
+                handlePerPageChange={handlePerPageChange}
+                currentSet={currentSet}
+                setUnapprovedIncidents={setUnapprovedIncidents}
+                setPageNumber={setPageNumber}
+                unapprovedIncidents={unapprovedIncidents}
+                setCurrList={setCurrList}
+              />
+            )}
             <ApprovedIncidents incidents={incidents} />
           </div>
         </>

--- a/src/components/graphs/bargraph/HorizontalBar.js
+++ b/src/components/graphs/bargraph/HorizontalBar.js
@@ -71,7 +71,6 @@ const Horizontalbar = () => {
 
   return (
     <div>
-      {console.log('LOOK HERE', dataList)}
       <div className="home-bar-graph">
         <h1>Incident Reports Grouped by Level of Police Force</h1>
         <p>

--- a/src/components/graphs/bargraph/HorizontalBar.js
+++ b/src/components/graphs/bargraph/HorizontalBar.js
@@ -71,6 +71,7 @@ const Horizontalbar = () => {
 
   return (
     <div>
+      {console.log('LOOK HERE', dataList)}
       <div className="home-bar-graph">
         <h1>Incident Reports Grouped by Level of Police Force</h1>
         <p>


### PR DESCRIPTION
#Loom Video Review Link

UI Changes: https://www.loom.com/share/1a81dd7f53b14a2f85634b12cf80074f
Code Changes: https://www.loom.com/share/44d8e60e2b7646259225eea8cb915ba5

##Description

Previously when you clicked create incident on the approved incidents list view within the admin dashboard, the add incident modal wasn't appearing. I simply copied over that functionality from the unapproved incidents list view and now it works for the approved incidents list view / ie the modal appears when you click create incident.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)


## Change Status

Complete, needs unit tests 

# How Has This Been Tested?

Repeatedly testing UI functionality, also a copy of previously working code, just re-using it somewhere new 

# Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] There are no merge conflicts
