### PR TITLE
Feature/incident confidence

### DIFF
--- a/src/components/AdminDashboard/CompleteIncident.js
+++ b/src/components/AdminDashboard/CompleteIncident.js
@@ -76,7 +76,6 @@ const CompleteIncident = props => {
         getData(setUnapprovedIncidents);
       });
   };
-  console.log('incident: ', incident);
 
   return (
     <div className="complete-incident">

--- a/src/components/AdminDashboard/CompleteIncident.js
+++ b/src/components/AdminDashboard/CompleteIncident.js
@@ -270,6 +270,14 @@ const CompleteIncident = props => {
               />
             </label>
 
+            {/* Confidence Rating: */}
+            <div className="dropdown-text-wrap">
+              <p className="complete-incident-dropdown-titles-bold">
+                Confidence Rating:
+              </p>
+              <p>{(incident.confidence * 100).toFixed(2)}%</p>
+            </div>
+
             {/* Cancel button */}
             <Button
               id="dropdown-edit-button"

--- a/src/components/AdminDashboard/CompleteIncident.js
+++ b/src/components/AdminDashboard/CompleteIncident.js
@@ -8,7 +8,6 @@ import { applyEdits, getData } from '../../utils/DashboardHelperFunctions';
 
 import './CompleteIncident.css';
 
-
 /**
  * @typedef CompleteIncidentProps
  * @property {any} incident - incident data
@@ -38,7 +37,7 @@ const CompleteIncident = props => {
   useEffect(() => {
     setFormValues({
       ...incident,
-      tags: incident.tags ? incident.tags.join(", ") : [],
+      tags: incident.tags ? incident.tags.join(', ') : [],
       incident_date: formattedDate,
     });
     return () => {
@@ -77,12 +76,12 @@ const CompleteIncident = props => {
         getData(setUnapprovedIncidents);
       });
   };
+  console.log('incident: ', incident);
 
   return (
     <div className="complete-incident">
       <div className="complete-incident-dropdown">
-
-        {!editing &&
+        {!editing && (
           <>
             {/* Date */}
             <div className="dropdown-text-wrap">
@@ -92,7 +91,9 @@ const CompleteIncident = props => {
 
             {/* Location */}
             <div className="dropdown-text-wrap">
-              <p className="complete-incident-dropdown-titles-bold">Location:</p>
+              <p className="complete-incident-dropdown-titles-bold">
+                Location:
+              </p>
               <p className="location-dropdown-wrap">
                 {incident.city}, {incident.state}
               </p>
@@ -100,9 +101,7 @@ const CompleteIncident = props => {
 
             {/* Title */}
             <div className="dropdown-text-wrap">
-              <p className="complete-incident-dropdown-titles-bold">
-                Title:
-              </p>
+              <p className="complete-incident-dropdown-titles-bold">Title:</p>
               <p>{incident.title || '(none)'}</p>
             </div>
 
@@ -124,7 +123,9 @@ const CompleteIncident = props => {
 
             {/* Sources */}
             <div className="dropdown-text-wrap">
-              <p className="complete-incident-dropdown-titles-bold">Source(s)</p>
+              <p className="complete-incident-dropdown-titles-bold">
+                Source(s):
+              </p>
               <div>
                 {incident.src.map(source => (
                   <div key={nanoid()}>
@@ -139,20 +140,30 @@ const CompleteIncident = props => {
 
             {/* Tags */}
             <div className="dropdown-text-wrap">
-              <p className="complete-incident-dropdown-titles-bold">Tags</p>
-              <div>
-                {incident.tags ? incident.tags.join(", ") : ''}
-              </div>
+              <p className="complete-incident-dropdown-titles-bold">Tags:</p>
+              <div>{incident.tags ? incident.tags.join(', ') : ''}</div>
+            </div>
+
+            {/* Confidence Rating: */}
+            <div className="dropdown-text-wrap">
+              <p className="complete-incident-dropdown-titles-bold">
+                Confidence Rating:
+              </p>
+              <p>{(incident.confidence * 100).toFixed(2)}%</p>
             </div>
 
             {/* Edit button */}
-            <Button id="dropdown-edit-button" className="approve-reject-select" onClick={toggleEditor}>
+            <Button
+              id="dropdown-edit-button"
+              className="approve-reject-select"
+              onClick={toggleEditor}
+            >
               Edit
             </Button>
           </>
-        }
+        )}
 
-        {editing &&
+        {editing && (
           <>
             {/* Date */}
             <label className="label">
@@ -247,7 +258,9 @@ const CompleteIncident = props => {
             {/* Tags */}
             <label className="label">
               Tags
-              <span style={{ fontWeight: "normal" }}>&nbsp;(comma separated values)</span>
+              <span style={{ fontWeight: 'normal' }}>
+                &nbsp;(comma separated values)
+              </span>
               <input
                 className="edit-input"
                 onChange={handleInputChange}
@@ -258,7 +271,11 @@ const CompleteIncident = props => {
             </label>
 
             {/* Cancel button */}
-            <Button id="dropdown-edit-button" className="approve-reject-select" onClick={toggleEditor}>
+            <Button
+              id="dropdown-edit-button"
+              className="approve-reject-select"
+              onClick={toggleEditor}
+            >
               Cancel
             </Button>
 
@@ -267,7 +284,7 @@ const CompleteIncident = props => {
               Apply Changes
             </Button>
           </>
-        }
+        )}
 
         <AntModal incident={incident} />
       </div>


### PR DESCRIPTION
# Description
This pull request adds a confidence rating to the incident card on the admin dashboard under the unapproved, approved, and edit tabs (though the confidence rating appears on editing for reference, it cannot be changed). This has been added to give the admin user more information and confidence about the incident and how closely it relates to the criteria used while scrapping tweets for hits.

Video Walkthrough: 
<a href="https://www.loom.com/share/27aa5328e92844049abd8d9df79ef9d5">
    <p>Feature/incident-confidence - Watch Video</p>
    <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/27aa5328e92844049abd8d9df79ef9d5-with-play.gif">
  </a>


- [ ] New feature (non-breaking change which adds functionality)

## Change Status

- [ ] Complete, tested, ready to review and merge
- [x] Complete, but not tested (may need new tests)


# How Has This Been Tested?

- [x] `npm test`

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
