### PR TITLE
add .vscode to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ yarn-debug.log*
 yarn-error.log*
 
 .eslintcache
+.vscode


### PR DESCRIPTION
# Description

This PR adds the .vscode directory to .gitignore.

.vscode folders are used for local workspace settings - custom launch figurations, project workspace specific settings, etc. Adding this to .gitignore allows individual developers to maintain their own configurations without cluttering the repo with files that aren't directly related to the project itself.

[More info](https://code.visualstudio.com/docs/getstarted/settings)

(Alternatively, we could use the .vscode folder to enforce shared project settings for every developer, but we'd probably never agree on what they should be. 😉)

## Type of change

- [x] Project configuration

## Change Status

- [x] Ready to go

# How Has This Been Tested?

- [x] No testing required

# Checklist

- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
