### PR TITLE
Feature/Display map incidents panel by default

### DIFF
--- a/src/components/Home/Map/IncidentFocus.js
+++ b/src/components/Home/Map/IncidentFocus.js
@@ -14,7 +14,7 @@ export default function IncidentFocus({ zoomOnCluster }) {
       <Collapse
         className="collapserMap"
         style={{ color: 'white' }}
-        defaultActiveKey={['0']}
+        defaultActiveKey={['1']}
         bordered={false}
         expandIcon={({ isActive }) => (
           <CaretRightOutlined rotate={isActive ? 90 : 0} />


### PR DESCRIPTION
# Description

[Video Explanation](https://www.loom.com/share/f0d59ddc16d84caabe5bd1763ba0a253)

This PR adds functionality to the home page map as discussed in the last Product Meeting. The goal of the map is for both exploration and information. Currently, the map's main function is only for exploration, as the incident report panel is closed by default. Instead of stumbling onto the informational panel feature, this PR opens the panel by default, so both the map and incident panel are always displayed. The PR leaves the panel as a toggle, so it can be closed if a user desires. 

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

## Change Status

- [ ] Complete, tested, ready to review and merge

# How Has This Been Tested?

- [ ] `npm test`

# Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] There are no merge conflicts
