### PR TITLE
bug/map-location-filter

### DIFF
--- a/src/hooks/useMapSearch.js
+++ b/src/hooks/useMapSearch.js
@@ -5,12 +5,6 @@ import moment from 'moment';
 import { mapActions } from '../store';
 const { setFocusGeoFilter, setFocusDateFilter, setFocusQuery } = mapActions;
 
-// These are set relatively low to be on the safe side because there were previous performance issues
-// displaying a large number of focus incidents - you may want to play around with adjusting them
-const GEO_RESULTS_LIMIT = 50;
-const DATE_RESULTS_LIMIT = 50;
-const OVERALL_RESULTS_LIMIT = 20;
-
 export default function useMapSearch() {
   const dispatch = useDispatch();
 
@@ -31,10 +25,6 @@ export default function useMapSearch() {
 
       // Decrementing for loop produces a reverse-chronological list (most recent first)
       for (let i = geoIncidentList.length - 1; i > 0; i--) {
-        if (matches.length >= GEO_RESULTS_LIMIT) {
-          break;
-        }
-
         const { id, lat, long } = geoIncidentList[i];
         if (
           lat >= minLat &&
@@ -55,7 +45,7 @@ export default function useMapSearch() {
   const dateIncidentList = useSelector(state =>
     state.incident.ids.map(id => ({
       id,
-      date: state.incident.data[id]?.date,
+      date: state.incident.data[id].incident_date,
     }))
   );
 
@@ -88,9 +78,6 @@ export default function useMapSearch() {
       dispatch(setFocusQuery(dateFilterState.list));
     } else if (geoFilterState.active && dateFilterState.active) {
       let matches = _.intersection(geoFilterState.list, dateFilterState.list);
-      if (matches.length > OVERALL_RESULTS_LIMIT) {
-        matches = _.slice(matches, 0, 10);
-      }
       dispatch(setFocusQuery(matches));
     }
   }, [geoFilterState, dateFilterState, dispatch]);


### PR DESCRIPTION
# Description
This PR fixes the location filter for the home's map clusters. Prior to this PR, the location filter results would only allow for a max of 50 incidents to be included for the location entered by the user. This PR eliminates the incident count limit to include all incidents by location thereby allowing the user to enter a city or state and the map will focus on that area and populate all the related incidents in clusters.

Before: Trying to filter by location, Portland, Oregon, would only yield a total of 50 incidents in the clusters.

![Screen Shot 2021-09-23 at 9 36 47 AM (2)](https://user-images.githubusercontent.com/78825655/134573269-d5801b84-02ab-421e-b282-d01385e2b184.png)


After: The map shows all incidents/clusters in the area according to the location filter (Portland, Oregon in this example).

![Screen Shot 2021-09-23 at 9 39 21 AM (2)](https://user-images.githubusercontent.com/78825655/134573280-70e18a7f-9486-4d13-a4ca-2f3205f17f80.png)



Video walk-through: https://www.loom.com/share/9b3881ec68974ed2b9cd19c74525389d 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Change Status

- [ ] Complete, tested, ready to review and merge
- [x] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

- [x] `npm test`

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
