### PR TITLE
Moved css fix to IncidentFocus.css with higher specificity

### DIFF
--- a/src/components/Home/Map/IncidentFocus.css
+++ b/src/components/Home/Map/IncidentFocus.css
@@ -1,5 +1,17 @@
 /* //incident div breakpoints */
 
+.collapserMap .ant-collapse-content-box {
+    background: #c1d2e9;
+}
+
+.collapserMap div.ant-collapse-header {
+    padding: 8px;
+    font-size: 1rem;
+    text-align: left;
+    font-weight: 400;
+    color: #212529;
+}
+
 @media (max-width: 1440px) {
     .collapseText.ant-collapse-item {
         margin: 0 3% 0 0 ;

--- a/src/components/Home/Map/IncidentFocus.css
+++ b/src/components/Home/Map/IncidentFocus.css
@@ -1,9 +1,5 @@
 /* //incident div breakpoints */
 
-.collapserMap .ant-collapse-content-box {
-    background: #c1d2e9;
-}
-
 .collapserMap div.ant-collapse-header {
     padding: 8px;
     font-size: 1rem;

--- a/src/index.css
+++ b/src/index.css
@@ -469,27 +469,12 @@ div.timeline-container {
 }
 
 .ant-collapse-content-box {
-  background-color: #c1d2e9;
   overflow: auto;
 }
 
 .incident-content {
   height: 50vh;
   z-index: 1;
-}
-
-div.ant-collapse-header {
-  padding: 4;
-  text-align: center;
-  padding-bottom: 4%;
-}
-
-div.ant-collapse > .ant-collapse-item > .ant-collapse-header {
-  padding: 8px;
-  font-size: 1rem;
-  text-align: left;
-  font-weight: 400;
-  color: #212529;
 }
 
 .incident-container {

--- a/src/index.css
+++ b/src/index.css
@@ -469,6 +469,7 @@ div.timeline-container {
 }
 
 .ant-collapse-content-box {
+  background: #c1d2e9;
   overflow: auto;
 }
 


### PR DESCRIPTION
# Description

[Explanation Video](https://www.loom.com/share/9d9b14f6e5ba415caf0dee9acc856c81)
Kelly's wonderful bug fix put the old css for collapse components back in index.css, which also applies to the other collapses such as the ones in the incident-reports page. This takes the selectors meant for the IncidentFocus component and makes them specific to that component. and I removed some of the unused properties like padding: 4, whatever that means.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change Status

- [X] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

- [X] `npm test`

# Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] There are no merge conflicts
