### PR TITLE
saving pageSize to local storage

### DIFF
--- a/src/components/AdminDashboard/AntTableComponents/AntTable.js
+++ b/src/components/AdminDashboard/AntTableComponents/AntTable.js
@@ -3,6 +3,7 @@ import { Table } from 'antd';
 import { DateTime } from 'luxon';
 
 import CompleteIncident from '../CompleteIncident';
+import useLocalStorage from '../../../hooks/useLocalStorage';
 
 //https://ant.design/components/table/ <---documentation on the table
 
@@ -23,6 +24,7 @@ import CompleteIncident from '../CompleteIncident';
 function AntTable(props) {
   const { selectedIds, setSelectedIds, incidents, showConfidence } = props;
 
+  const [itemsPerPage, setItemsPerPage] = useLocalStorage('admin-dashboard-items-per-page', 10);
   const [selectedRows, setSelectedRows] = useState([]);
 
   // formats the date in the table
@@ -37,6 +39,14 @@ function AntTable(props) {
       setSelectedIds(selectedIncidents);
     } else {
       setSelectedRows(selectedIncidents);
+    }
+  };
+
+  // handler for changing page size
+  // note: it's not necessary to track the current page, the Table component will handle that
+  const onPageChanged = (page, pageSize) => {
+    if (pageSize !== itemsPerPage) {
+      setItemsPerPage(pageSize);
     }
   };
 
@@ -118,6 +128,8 @@ function AntTable(props) {
           showTotal(total, range) {
             return `${range[0]}-${range[1]} of ${total} items`;
           },
+          pageSize: itemsPerPage,
+          onChange: onPageChanged
         }}
       />
     </div>


### PR DESCRIPTION
# Description

[Video](https://www.loom.com/share/cd69065e5bc94b049855ef58a1398588)

This simple PR is updates the 'page size' setting on the AdminDashboard so that it stays the same even if you change pages or reload.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Change Status

- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?

- [x] `npm test`

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
